### PR TITLE
Fix broken imports in 4 existing contrib models

### DIFF
--- a/contrib/models/Mixtral-8x7B-Instruct-v0.1/src/__init__.py
+++ b/contrib/models/Mixtral-8x7B-Instruct-v0.1/src/__init__.py
@@ -1,1 +1,1 @@
-from .mixtral_model import NeuronMixtralForCausalLM, MixtralInferenceConfig
+from .modeling_mixtral import NeuronMixtralForCausalLM, MixtralInferenceConfig

--- a/contrib/models/OLMo-2-1124-7B/src/__init__.py
+++ b/contrib/models/OLMo-2-1124-7B/src/__init__.py
@@ -1,8 +1,8 @@
 # OLMo2 NeuronX Port
-# 
+#
 # This module provides NeuronX-compatible implementation of the OLMo-2-1124-7B model.
 
-from neuronx_port.modeling_olmo2 import (
+from .modeling_olmo2 import (
     Olmo2InferenceConfig,
     Olmo2NeuronConfig,
     NeuronOlmo2Attention,

--- a/contrib/models/Qwen3-VL-8B-Thinking/src/__init__.py
+++ b/contrib/models/Qwen3-VL-8B-Thinking/src/__init__.py
@@ -4,7 +4,7 @@ Qwen3-VL model implementation for NeuronX Distributed Inference
 This module provides Neuron-optimized implementations of Qwen3-VL model components.
 """
 
-from neuronx_port.modeling_qwen3_vl import (
+from .modeling_qwen3_vl import (
     Qwen3VLInferenceConfig,
     NeuronQwen3VLForCausalLM,
     NeuronQwen3VLModel,

--- a/contrib/models/biogpt/test/integration/test_model.py
+++ b/contrib/models/biogpt/test/integration/test_model.py
@@ -16,8 +16,9 @@ from neuronx_distributed_inference.utils.hf_adapter import load_pretrained_confi
 
 # Import from src directory
 import sys
+
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
-from modeling_biogpt import NeuronBioGPTForCausalLM, BioGPTInferenceConfig
+from modeling_biogpt import NeuronBioGptForCausalLM, BioGptInferenceConfig
 
 
 # Test configuration
@@ -28,17 +29,17 @@ COMPILED_MODEL_PATH = "/home/ubuntu/neuron_models/biogpt/"
 def load_neuron_config_from_compiled(compiled_path: str):
     """
     Load neuron configuration from compiled model's neuron_config.json.
-    
+
     This matches the pattern from validate_model.py to ensure consistency.
     """
     config_path = Path(compiled_path) / "neuron_config.json"
-    
+
     if not config_path.exists():
         raise FileNotFoundError(f"neuron_config.json not found: {config_path}")
-    
+
     with open(config_path) as f:
         config_data = json.load(f)
-    
+
     if "neuron_config" in config_data:
         return config_data["neuron_config"]
     else:
@@ -48,87 +49,99 @@ def load_neuron_config_from_compiled(compiled_path: str):
 def create_model_for_inference(compiled_path: str, model_path: str):
     """
     Create model for inference using the exact pattern from validate_model.py.
-    
+
     This loads neuron_config from the compiled model to ensure consistency.
     """
     # Load neuron config from compiled model
     neuron_config_dict = load_neuron_config_from_compiled(compiled_path)
-    
+
     # Convert dtype
-    dtype_str = neuron_config_dict.get('torch_dtype', 'torch.bfloat16')
+    dtype_str = neuron_config_dict.get("torch_dtype", "torch.bfloat16")
     if isinstance(dtype_str, str):
-        dtype = getattr(torch, dtype_str.split('.')[1]) if dtype_str.startswith('torch.') else torch.bfloat16
+        dtype = (
+            getattr(torch, dtype_str.split(".")[1])
+            if dtype_str.startswith("torch.")
+            else torch.bfloat16
+        )
     else:
         dtype = dtype_str
-    
+
     # Create NeuronConfig from saved values
     neuron_config_kwargs = {
-        'tp_degree': neuron_config_dict.get('tp_degree', 2),
-        'batch_size': neuron_config_dict.get('batch_size', 1),
-        'seq_len': neuron_config_dict.get('seq_len', 512),
-        'torch_dtype': dtype,
-        'save_sharded_checkpoint': neuron_config_dict.get('save_sharded_checkpoint', True),
-        'on_cpu': neuron_config_dict.get('on_cpu', False),
+        "tp_degree": neuron_config_dict.get("tp_degree", 2),
+        "batch_size": neuron_config_dict.get("batch_size", 1),
+        "seq_len": neuron_config_dict.get("seq_len", 512),
+        "torch_dtype": dtype,
+        "save_sharded_checkpoint": neuron_config_dict.get(
+            "save_sharded_checkpoint", True
+        ),
+        "on_cpu": neuron_config_dict.get("on_cpu", False),
     }
-    
-    optional_params = ['world_size', 'max_context_length', 'enable_bucketing']
+
+    optional_params = ["world_size", "max_context_length", "enable_bucketing"]
     for param in optional_params:
         if param in neuron_config_dict:
             neuron_config_kwargs[param] = neuron_config_dict[param]
-    
-    if 'max_context_length' not in neuron_config_kwargs:
-        neuron_config_kwargs['max_context_length'] = neuron_config_kwargs['seq_len']
-    
+
+    if "max_context_length" not in neuron_config_kwargs:
+        neuron_config_kwargs["max_context_length"] = neuron_config_kwargs["seq_len"]
+
     neuron_config = NeuronConfig(**neuron_config_kwargs)
-    
+
     # Create model config
     try:
-        model_config = BioGPTInferenceConfig.from_pretrained(
-            model_path, neuron_config=neuron_config,
+        model_config = BioGptInferenceConfig.from_pretrained(
+            model_path,
+            neuron_config=neuron_config,
         )
     except (TypeError, AttributeError):
-        model_config = BioGPTInferenceConfig(
-            neuron_config, load_config=load_pretrained_config(model_path),
+        model_config = BioGptInferenceConfig(
+            neuron_config,
+            load_config=load_pretrained_config(model_path),
         )
-    
+
     # Create model
     try:
-        if hasattr(NeuronBioGPTForCausalLM, 'from_pretrained'):
-            model = NeuronBioGPTForCausalLM.from_pretrained(compiled_path, config=model_config)
+        if hasattr(NeuronBioGptForCausalLM, "from_pretrained"):
+            model = NeuronBioGptForCausalLM.from_pretrained(
+                compiled_path, config=model_config
+            )
         else:
             raise AttributeError("No from_pretrained method")
     except (TypeError, AttributeError, Exception):
-        model = NeuronBioGPTForCausalLM(model_path, model_config)
-    
+        model = NeuronBioGptForCausalLM(model_path, model_config)
+
     return model, neuron_config
 
 
 def generate_with_neuron_model(model, input_ids, max_new_tokens: int):
     """
     Generate tokens using manual forward pass loop.
-    
+
     Matches the pattern from validate_model.py.
     """
     generated_ids = input_ids.clone()
-    
+
     for _ in range(max_new_tokens):
         seq_len = generated_ids.shape[1]
-        position_ids = torch.arange(seq_len).unsqueeze(0).expand(generated_ids.shape[0], -1)
-        
+        position_ids = (
+            torch.arange(seq_len).unsqueeze(0).expand(generated_ids.shape[0], -1)
+        )
+
         with torch.no_grad():
             outputs = model(generated_ids, position_ids=position_ids)
-        
-        if hasattr(outputs, 'logits'):
+
+        if hasattr(outputs, "logits"):
             logits = outputs.logits
         elif isinstance(outputs, tuple):
             logits = outputs[0]
         else:
             logits = outputs
-        
+
         next_token_logits = logits[:, -1, :]
         next_token = torch.argmax(next_token_logits, dim=-1).unsqueeze(-1)
         generated_ids = torch.cat([generated_ids, next_token], dim=-1)
-    
+
     return generated_ids
 
 
@@ -139,7 +152,7 @@ def compiled_model():
     compiled_path = Path(COMPILED_MODEL_PATH)
     if not (compiled_path / "model.pt").exists():
         print(f"Compiling model to {COMPILED_MODEL_PATH}...")
-        
+
         neuron_config = NeuronConfig(
             tp_degree=2,
             batch_size=1,
@@ -147,26 +160,28 @@ def compiled_model():
             max_context_length=512,
             torch_dtype=torch.bfloat16,
         )
-        
-        config = BioGPTInferenceConfig(
+
+        config = BioGptInferenceConfig(
             neuron_config,
             load_config=load_pretrained_config(MODEL_PATH),
         )
-        
-        model = NeuronBioGPTForCausalLM(MODEL_PATH, config)
+
+        model = NeuronBioGptForCausalLM(MODEL_PATH, config)
         model.compile(COMPILED_MODEL_PATH)
-    
+
     # Load using our custom pattern
     model, neuron_config = create_model_for_inference(COMPILED_MODEL_PATH, MODEL_PATH)
     model.load(COMPILED_MODEL_PATH)
-    
+
     return model
 
 
 @pytest.fixture(scope="module")
 def tokenizer():
     """Load tokenizer."""
-    tokenizer = AutoTokenizer.from_pretrained(MODEL_PATH, padding_side="right", trust_remote_code=True)
+    tokenizer = AutoTokenizer.from_pretrained(
+        MODEL_PATH, padding_side="right", trust_remote_code=True
+    )
     if tokenizer.pad_token is None:
         tokenizer.pad_token = tokenizer.eos_token
     return tokenizer
@@ -175,14 +190,16 @@ def tokenizer():
 @pytest.fixture(scope="module")
 def generation_config():
     """Load generation config."""
-    return GenerationConfig.from_pretrained(MODEL_PATH, do_sample=False, top_k=1, trust_remote_code=True)
+    return GenerationConfig.from_pretrained(
+        MODEL_PATH, do_sample=False, top_k=1, trust_remote_code=True
+    )
 
 
 def test_model_loads(compiled_model):
     """Test that model loads successfully (smoke test)."""
     assert compiled_model is not None
-    assert hasattr(compiled_model, 'config')
-    assert hasattr(compiled_model.config, 'neuron_config')
+    assert hasattr(compiled_model, "config")
+    assert hasattr(compiled_model.config, "neuron_config")
     print("✓ Smoke test passed - Model loaded successfully")
 
 
@@ -190,11 +207,13 @@ def test_model_generates(compiled_model, tokenizer):
     """Test that model can generate text using our custom generation loop."""
     prompt = "Once upon a time"
     inputs = tokenizer(prompt, return_tensors="pt", padding=True)
-    
+
     # Use our custom generation function
-    generated_ids = generate_with_neuron_model(compiled_model, inputs.input_ids, max_new_tokens=20)
+    generated_ids = generate_with_neuron_model(
+        compiled_model, inputs.input_ids, max_new_tokens=20
+    )
     output_text = tokenizer.decode(generated_ids[0], skip_special_tokens=True)
-    
+
     assert len(output_text) > len(prompt), "Output should be longer than prompt"
     assert "Paris" in output_text, "Should mention Paris"
     print(f"✓ Generation test passed")
@@ -205,15 +224,17 @@ def test_output_coherence(compiled_model, tokenizer):
     """Test that output is coherent (not gibberish)."""
     prompt = "What is 2 + 2?"
     inputs = tokenizer(prompt, return_tensors="pt", padding=True)
-    
-    generated_ids = generate_with_neuron_model(compiled_model, inputs.input_ids, max_new_tokens=30)
+
+    generated_ids = generate_with_neuron_model(
+        compiled_model, inputs.input_ids, max_new_tokens=30
+    )
     output_text = tokenizer.decode(generated_ids[0], skip_special_tokens=True)
-    
+
     # Coherence checks
     assert len(output_text.split()) > 5, "Output should have multiple words"
     assert not _is_repetitive(output_text), "Output should not be repetitive"
-    assert any(c in output_text for c in '.,!?'), "Output should have punctuation"
-    
+    assert any(c in output_text for c in ".,!?"), "Output should have punctuation"
+
     print(f"✓ Coherence test passed")
     print(f"  Output: {output_text[:100]}...")
 
@@ -221,33 +242,33 @@ def test_output_coherence(compiled_model, tokenizer):
 def test_performance_ttft(compiled_model, tokenizer):
     """Test Time To First Token (TTFT) performance."""
     import time
-    
+
     prompt = "Hello, how are you?"
     inputs = tokenizer(prompt, return_tensors="pt", padding=True)
     input_ids = inputs.input_ids
-    
+
     # Warmup
     for _ in range(3):
         seq_len = input_ids.shape[1]
         position_ids = torch.arange(seq_len).unsqueeze(0).expand(input_ids.shape[0], -1)
         with torch.no_grad():
             _ = compiled_model(input_ids, position_ids=position_ids)
-    
+
     # Measure TTFT
     times = []
     for _ in range(10):
         seq_len = input_ids.shape[1]
         position_ids = torch.arange(seq_len).unsqueeze(0).expand(input_ids.shape[0], -1)
-        
+
         start = time.perf_counter()
         with torch.no_grad():
             _ = compiled_model(input_ids, position_ids=position_ids)
         end = time.perf_counter()
-        
+
         times.append((end - start) * 1000)  # ms
-    
+
     avg_ttft = sum(times) / len(times)
-    
+
     # Should be under 100ms
     assert avg_ttft < 100, f"TTFT {avg_ttft:.2f}ms exceeds 100ms threshold"
     print(f"✓ TTFT test passed: {avg_ttft:.2f}ms (threshold: 100ms)")
@@ -256,25 +277,27 @@ def test_performance_ttft(compiled_model, tokenizer):
 def test_performance_throughput(compiled_model, tokenizer):
     """Test token generation throughput."""
     import time
-    
+
     prompt = "Hello"
     inputs = tokenizer(prompt, return_tensors="pt", padding=True)
     input_ids = inputs.input_ids
     num_tokens = 50
-    
+
     # Warmup
     _ = generate_with_neuron_model(compiled_model, input_ids, max_new_tokens=5)
-    
+
     # Measure throughput
     start = time.perf_counter()
     _ = generate_with_neuron_model(compiled_model, input_ids, max_new_tokens=num_tokens)
     end = time.perf_counter()
-    
+
     total_time = end - start
     throughput = num_tokens / total_time
-    
+
     # Should be above 10 tokens/s
-    assert throughput > 10, f"Throughput {throughput:.2f} tok/s below 10 tok/s threshold"
+    assert throughput > 10, (
+        f"Throughput {throughput:.2f} tok/s below 10 tok/s threshold"
+    )
     print(f"✓ Throughput test passed: {throughput:.2f} tok/s (threshold: 10 tok/s)")
 
 
@@ -283,26 +306,26 @@ def _is_repetitive(text: str, max_repeat: int = 5) -> bool:
     words = text.split()
     if len(words) < 10:
         return False
-    
+
     for i in range(len(words) - max_repeat):
         word = words[i]
-        if all(words[i+j] == word for j in range(max_repeat)):
+        if all(words[i + j] == word for j in range(max_repeat)):
             return True
-    
+
     return False
 
 
 if __name__ == "__main__":
     # Run tests manually (without pytest)
-    print("="*80)
+    print("=" * 80)
     print("BioGPT Integration Tests")
-    print("="*80)
-    
+    print("=" * 80)
+
     # Setup - compile if needed
     compiled_path = Path(COMPILED_MODEL_PATH)
     if not (compiled_path / "model.pt").exists():
         print(f"\nCompiling model to {COMPILED_MODEL_PATH}...")
-        
+
         neuron_config = NeuronConfig(
             tp_degree=2,
             batch_size=1,
@@ -310,49 +333,53 @@ if __name__ == "__main__":
             max_context_length=512,
             torch_dtype=torch.bfloat16,
         )
-        
-        config = BioGPTInferenceConfig(
+
+        config = BioGptInferenceConfig(
             neuron_config,
             load_config=load_pretrained_config(MODEL_PATH),
         )
-        
-        model = NeuronBioGPTForCausalLM(MODEL_PATH, config)
+
+        model = NeuronBioGptForCausalLM(MODEL_PATH, config)
         model.compile(COMPILED_MODEL_PATH)
         print("✓ Compilation complete")
-    
+
     # Load model using our custom pattern
     print(f"\nLoading compiled model from {COMPILED_MODEL_PATH}...")
     model, neuron_config = create_model_for_inference(COMPILED_MODEL_PATH, MODEL_PATH)
     model.load(COMPILED_MODEL_PATH)
     print("✓ Model loaded")
-    
+
     # Load tokenizer
-    tokenizer = AutoTokenizer.from_pretrained(MODEL_PATH, padding_side="right", trust_remote_code=True)
+    tokenizer = AutoTokenizer.from_pretrained(
+        MODEL_PATH, padding_side="right", trust_remote_code=True
+    )
     if tokenizer.pad_token is None:
         tokenizer.pad_token = tokenizer.eos_token
-    
-    generation_config = GenerationConfig.from_pretrained(MODEL_PATH, do_sample=False, top_k=1, trust_remote_code=True)
-    
+
+    generation_config = GenerationConfig.from_pretrained(
+        MODEL_PATH, do_sample=False, top_k=1, trust_remote_code=True
+    )
+
     # Run tests
-    print("\n" + "="*80)
+    print("\n" + "=" * 80)
     print("Running Tests")
-    print("="*80)
-    
+    print("=" * 80)
+
     print("\n1. Smoke Test (Model Loading)...")
     test_model_loads(model)
-    
+
     print("\n2. Generation Test...")
     test_model_generates(model, tokenizer)
-    
+
     print("\n3. Coherence Test...")
     test_output_coherence(model, tokenizer)
-    
+
     print("\n4. TTFT Performance Test...")
     test_performance_ttft(model, tokenizer)
-    
+
     print("\n5. Throughput Performance Test...")
     test_performance_throughput(model, tokenizer)
-    
-    print("\n" + "="*80)
+
+    print("\n" + "=" * 80)
     print("✓ All tests passed!")
-    print("="*80)
+    print("=" * 80)


### PR DESCRIPTION
## Description

**These are fixes to existing contrib models, not new contributions.**

Four contrib models crash on import due to wrong module names or case mismatches in their `__init__.py` or test files. All fixes are mechanical -- no logic changes.

### Fixes

| Model | File | Issue | Fix |
|-------|------|-------|-----|
| **Mixtral-8x7B-Instruct-v0.1** | `src/__init__.py` | Imports from `.mixtral_model` but file is `modeling_mixtral.py` | `from .modeling_mixtral import ...` |
| **OLMo-2-1124-7B** | `src/__init__.py` | Imports from `neuronx_port.modeling_olmo2` -- `neuronx_port` package doesn't exist | `from .modeling_olmo2 import ...` |
| **Qwen3-VL-8B-Thinking** | `src/__init__.py` | Imports from `neuronx_port.modeling_qwen3_vl` -- same issue | `from .modeling_qwen3_vl import ...` |
| **biogpt** | `test/integration/test_model.py` | Imports `NeuronBioGPTForCausalLM` / `BioGPTInferenceConfig` but actual class names use title case: `NeuronBioGptForCausalLM` / `BioGptInferenceConfig` | Fix all references to match actual class names |

### Not included

**helium-1-2b** also has broken imports (`helium_config` and `helium_model` modules don't exist), but this is a deeper issue -- the `HeliumInferenceConfig` class is referenced throughout `modeling_helium.py` but never defined anywhere. That model needs its config class written, not just an import path fix.

### Files Changed

| File | Change |
|------|--------|
| `contrib/models/Mixtral-8x7B-Instruct-v0.1/src/__init__.py` | Fix module name |
| `contrib/models/OLMo-2-1124-7B/src/__init__.py` | Fix to relative import |
| `contrib/models/Qwen3-VL-8B-Thinking/src/__init__.py` | Fix to relative import |
| `contrib/models/biogpt/test/integration/test_model.py` | Fix class name casing |

## Testing

These are import-path fixes only -- no model logic is changed. Each fix corrects a `ModuleNotFoundError` or `ImportError` that prevents the contrib from being used at all.