### PR TITLE
Fix script injection in auto-label workflow

### DIFF
--- a/.github/workflows/auto-label-issues.yml
+++ b/.github/workflows/auto-label-issues.yml
@@ -197,13 +197,17 @@ jobs:
 
       - name: Apply labels to issue
         if: steps.analyze_content.outputs.has_labels == 'true'
+        uses: actions/github-script@v7
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ISSUE_NUMBER: ${{ github.event.issue.number }}
-          REPO: ${{ github.repository }}
           LABELS: ${{ steps.analyze_content.outputs.labels }}
-        run: |
-          IFS=',' read -ra LABEL_ARRAY <<< "$LABELS"
-          for label in "${LABEL_ARRAY[@]}"; do
-            gh issue edit "$ISSUE_NUMBER" --add-label "$label" -R "$REPO"
-          done
+        with:
+          script: |
+            const labels = process.env.LABELS.split(',').filter(l => l.trim());
+            if (labels.length > 0) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                labels: labels
+              });
+            }


### PR DESCRIPTION
## Summary

Resolves ACAT/Talos script injection finding in `.github/workflows/auto-label-issues.yml`.

**Ticket:** V2151977531


## What changed

Replaced the shell-based `run:` step (which used `gh issue edit` via CLI) with `actions/github-script@v7` that calls the GitHub REST API directly in JavaScript.

This ensures untrusted user input (issue title/body → labels) never passes through a shell interpreter.

## Testing

- The workflow logic is unchanged — labels are still split by comma and applied to the issue.
- `actions/github-script` provides the auth token automatically, so `GITHUB_TOKEN` env var is no longer needed explicitly.
- `context.repo` and `context.issue` replace the removed `REPO` and `ISSUE_NUMBER` env vars.