### PR TITLE
ci: add Claude Code PR review and @claude responder workflows

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,57 @@
+# Automated Claude Code review for pull requests.
+# Runs on every PR open/update and posts inline + summary review comments.
+#
+# Authentication uses Amazon Bedrock via GitHub OIDC (no long-lived API key).
+# One-time setup is required by a repo admin -- see docs/claude-code-review.md.
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+# Fork PRs do not receive secrets/OIDC credentials, so the review job is a no-op
+# for them. Auto-review runs for pull requests from branches within this repo.
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write # required for AWS OIDC
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.CLAUDE_CODE_BEDROCK_ROLE_ARN }}
+          aws-region: ${{ vars.CLAUDE_CODE_AWS_REGION || 'us-west-2' }}
+
+      - name: Review PR
+        uses: anthropics/claude-code-action@v1
+        with:
+          use_bedrock: "true"
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            Please review this pull request with a focus on:
+            - Correctness bugs and potential runtime errors
+            - Numerical / accuracy regressions in model or kernel code
+            - Neuron/Trainium-specific concerns (tensor/expert parallelism,
+              dtype handling, compilation constraints, sharding)
+            - Security implications
+            - Performance considerations
+            - Code quality and adherence to existing conventions
+
+            Note: The PR branch is already checked out in the current working directory.
+
+            Use `gh pr comment` for a concise top-level summary.
+            Use `mcp__github_inline_comment__create_inline_comment` (with `confirmed: true`)
+            to flag specific lines. Keep feedback actionable and avoid nitpicking.
+            Only post GitHub comments -- don't submit review text as chat messages.
+          claude_args: |
+            --model ${{ vars.CLAUDE_CODE_BEDROCK_MODEL || 'us.anthropic.claude-sonnet-4-5-20250929-v1:0' }}
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"

--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -1,0 +1,49 @@
+# Interactive Claude Code responder.
+# Triggers when someone mentions @claude in an issue, PR comment, PR review,
+# or review comment. Claude reads the context and responds / makes changes.
+#
+# Authentication uses Amazon Bedrock via GitHub OIDC (no long-lived API key).
+# One-time setup is required by a repo admin -- see docs/claude-code-review.md.
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+  issues:
+    types: [opened, assigned]
+
+jobs:
+  claude:
+    # Only run when @claude is mentioned, to avoid spending on every comment.
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write # required for AWS OIDC
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.CLAUDE_CODE_BEDROCK_ROLE_ARN }}
+          aws-region: ${{ vars.CLAUDE_CODE_AWS_REGION || 'us-west-2' }}
+
+      - name: Run Claude Code
+        uses: anthropics/claude-code-action@v1
+        with:
+          use_bedrock: "true"
+          claude_args: |
+            --model ${{ vars.CLAUDE_CODE_BEDROCK_MODEL || 'us.anthropic.claude-sonnet-4-5-20250929-v1:0' }}

--- a/docs/claude-code-review.md
+++ b/docs/claude-code-review.md
@@ -1,0 +1,110 @@
+# Claude Code on GitHub
+
+This repository uses [Claude Code](https://github.com/anthropics/claude-code-action)
+to help review pull requests and respond to `@claude` mentions.
+
+Two workflows are provided:
+
+| Workflow | File | Trigger |
+| --- | --- | --- |
+| **Claude Code Review** | `.github/workflows/claude-code-review.yml` | Automatically on every PR (`opened`, `synchronize`) |
+| **Claude Code** (interactive) | `.github/workflows/claude-code.yml` | When `@claude` is mentioned in an issue, PR comment, or review |
+
+Authentication is via **Amazon Bedrock using GitHub OIDC** — no long-lived
+Anthropic API key is stored in the repository.
+
+## One-time setup (repo admin)
+
+The workflows will no-op until an admin completes the steps below.
+
+### 1. Create a GitHub OIDC identity provider in your AWS account
+
+If your account doesn't already have one:
+
+- Provider URL: `https://token.actions.githubusercontent.com`
+- Audience: `sts.amazonaws.com`
+
+### 2. Create an IAM role the workflows can assume
+
+Create a role with a trust policy scoped to this repository. Example
+(replace `<ACCOUNT_ID>` and confirm the `sub` scope matches your needs):
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Federated": "arn:aws:iam::<ACCOUNT_ID>:oidc-provider/token.actions.githubusercontent.com"
+      },
+      "Action": "sts:AssumeRoleWithWebIdentity",
+      "Condition": {
+        "StringEquals": {
+          "token.actions.githubusercontent.com:aud": "sts.amazonaws.com"
+        },
+        "StringLike": {
+          "token.actions.githubusercontent.com:sub": "repo:aws-neuron/neuronx-distributed-inference:*"
+        }
+      }
+    }
+  ]
+}
+```
+
+Attach a permissions policy allowing Bedrock model invocation:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "bedrock:InvokeModel",
+        "bedrock:InvokeModelWithResponseStream"
+      ],
+      "Resource": "*"
+    }
+  ]
+}
+```
+
+> Scope `Resource` to specific model/inference-profile ARNs if your security
+> posture requires it. Some Claude models on Bedrock use cross-region inference
+> profiles, so grant access in every region the profile spans.
+
+### 3. Request Bedrock model access
+
+In the Bedrock console (in the region you'll use), request access to the Claude
+model you intend to run — by default the workflows use
+`us.anthropic.claude-sonnet-4-5-20250929-v1:0`.
+
+### 4. Configure the repository secret and variables
+
+Under **Settings → Secrets and variables → Actions**:
+
+**Secret (required):**
+
+- `CLAUDE_CODE_BEDROCK_ROLE_ARN` — ARN of the IAM role from step 2.
+
+**Variables (optional — sensible defaults are built in):**
+
+- `CLAUDE_CODE_AWS_REGION` — Bedrock region (default `us-west-2`).
+- `CLAUDE_CODE_BEDROCK_MODEL` — Bedrock model id / inference-profile id
+  (default `us.anthropic.claude-sonnet-4-5-20250929-v1:0`).
+
+## Notes
+
+- **Fork pull requests**: This is a public repository. PRs opened from forks do
+  not receive OIDC credentials, so the auto-review job is a no-op for them. It
+  runs for PRs from branches within this repository. This is the safe default —
+  it avoids exposing credentials to untrusted PR code. To review fork PRs, a
+  maintainer can `@claude` on the PR from a trusted context, or the workflow can
+  later be extended with a label-gated `pull_request_target` trigger (review the
+  [security implications](https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/)
+  first).
+- **Cost control**: The interactive workflow only runs when a comment/issue
+  contains `@claude`. The review workflow runs once per PR push.
+- To disable a workflow without deleting it, disable it under the repo's
+  **Actions** tab, or delete the corresponding file.


### PR DESCRIPTION
## What

Adds automated code review by [Claude Code](https://github.com/anthropics/claude-code-action) to this repository via two GitHub Actions workflows:

| Workflow | File | Trigger |
| --- | --- | --- |
| **Claude Code Review** | `.github/workflows/claude-code-review.yml` | Every PR (`opened`, `synchronize`) — posts inline + summary review comments |
| **Claude Code** (interactive) | `.github/workflows/claude-code.yml` | `@claude` mention in an issue, PR comment, or review |

The review prompt is tuned for this repo: alongside general correctness/security/performance, it asks Claude to watch for numerical/accuracy regressions and Neuron/Trainium-specific concerns (tensor/expert parallelism, dtype handling, compilation constraints, sharding).

## Authentication

Uses **Amazon Bedrock via GitHub OIDC** — no long-lived Anthropic API key is stored in the repo. Model, region, and role ARN are configurable through repo secrets/variables with sensible defaults (`us.anthropic.claude-sonnet-4-5-20250929-v1:0`, `us-west-2`).

## Required admin setup (before it works)

The workflows no-op until a repo admin completes the one-time setup in **[`docs/claude-code-review.md`](docs/claude-code-review.md)**:

1. GitHub OIDC identity provider in the AWS account.
2. IAM role trusted for `repo:aws-neuron/neuronx-distributed-inference:*` with `bedrock:InvokeModel` permission.
3. Bedrock model access request in the target region.
4. Repo secret `CLAUDE_CODE_BEDROCK_ROLE_ARN` (+ optional `CLAUDE_CODE_AWS_REGION` / `CLAUDE_CODE_BEDROCK_MODEL` variables).

## Notes / safety

- **Public repo → fork PRs get no credentials**, so auto-review is a deliberate no-op for them and runs only for in-repo branches. This avoids exposing credentials to untrusted PR code. Reviewing fork PRs would require a label-gated `pull_request_target` flow, intentionally left out.
- **Cost control**: the interactive workflow only fires on an explicit `@claude` mention; the review workflow runs once per PR push.
- Least-privilege permissions on each job; `id-token: write` only where OIDC is needed.

Follows the existing `github-script`-based workflow conventions already in `.github/workflows/`.